### PR TITLE
Improve processing speeds and error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/DarthCucumber/gofuzz/pkg/data"
 	"github.com/DarthCucumber/gofuzz/pkg/utils"
@@ -70,6 +72,7 @@ func main() {
 	parsedChar.MetaData = session
 	parsedInput.MetaData = session
 
+	startTime := time.Now()
 	session.DisplayInfo()
 	//begin the fuzzing process
 
@@ -78,6 +81,7 @@ func main() {
 	parsedChar.BeginFuzzing("character")
 	parsedInput.BeginFuzzing("file data")
 
+	utils.ShowSuccess(fmt.Sprintf("Fuzzing take %f seconds finish!", time.Since(startTime).Seconds()))
 	utils.ShowSuccess("Fuzzing Complete!\n")
 	// fmt.Printf("%+v\n", parsedNum.Result)
 	// fmt.Printf("%+v\n", parsedAscii.Result)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	flag.StringVar(&options.ExportType, "export", "json", "data format (json/txt) in which the result will be stored in the output file. (default:json)")
 	flag.StringVar(&options.Method, "m", "HEAD", "Request method [HEAD/GET/POST]")
 	flag.IntVar(&options.Timeout, "t", 30000, "takes in timout for each requests in milliseconds. (Default: 30000 ms or 30 s)")
+	flag.IntVar(&options.Retries, "r", 3, "takes in how many times it will try a request if returns an error. (Default: 3 attempts for each request)")
 	flag.StringVar(&options.Exclude, "exclude", "", "takes in status code separated by commas to be excluded from display result, however everything is included in the result files")
 	flag.Parse()
 
@@ -45,6 +46,8 @@ func main() {
 	session.ParsedUrl = options.ParseUrl()
 	//set timeout
 	session.Timeout = options.Timeout
+	//set retries
+	session.Retries = options.Retries
 	//check for valid export type(-e)
 	session.ExportType = options.SetExportType()
 	//check for valid request method(-m)

--- a/pkg/data/options.go
+++ b/pkg/data/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	Host       string
 	Exclude    string
 	Timeout    int
+	Retries    int
 }
 
 //exclude status code functionality
@@ -232,7 +233,7 @@ Options:
 
 display help/usage menu
 
--u  
+-u
 
 takes in target URL for fuzzing. User placeholder <@>
 Ex: -u "http://target.com/q1=<@>&q2=<@>"
@@ -240,25 +241,25 @@ NOTE: Try to enclose URL in qotes as the placeholder may cause issue in terminal
 
 -n
 
-takes in comma separated number. 
+takes in comma separated number.
 Ex: -n 12  implies gofuzz will test for numbers from 0 to 12
 -n 12,100  implies gofuzz will test for numbers from 12 to 100
 -n 12,13,14,11  implies gofuzz will test for numbers 12,13,14,11
 
--a  
+-a
 
 takes in comma sparated ASCII values and extended ASCII values and test for the corresponding character of those values.
 Ex: -a 65  implies gofuzz will test for "A"
 -a 65,90  implies gofuzz will test for "A" to "Z"
 -a 65,70,66  implies gofuzz will test for "A","F" and "B"
 
--c  
+-c
 
 takes in characters as input, mainly used for passing symbols.
 NOTE: try to enclose the string in quotes or use forward slash to escape shell characters
 Ex: -c "\&,@,#" implies gofuzz will test for "&","@","#"
 
--m  
+-m
 
 takes in GET/POST/HEAD request methods as input (default: HEAD)
 NOTE: POST doesn't work for now
@@ -267,11 +268,15 @@ NOTE: POST doesn't work for now
 
 Time to wait for each request. Takes in time in milliseconds (default: 30000 ms or 30 s)
 
+-r
+
+How many times attempts a request can have in case of error (default: 3)
+
 -o
 
 Output directory where results will be stored. (Default: ./output)
 
--export 
+-export
 
 takes txt/json export type as input (default and preffered: json)
 

--- a/pkg/utils/requests.go
+++ b/pkg/utils/requests.go
@@ -10,9 +10,23 @@ import (
 )
 
 // make concurrent requests
-func MakeRequest(method, url string, t int, out chan []string, wg *sync.WaitGroup) {
+func MakeRequest(method, url string, customTransport *http.Transport, t, rt int, out chan []string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	// TODO: add client timeout
+	var (
+		res              *http.Response
+		err              error
+		keepAliveTimeout = time.Duration(5) * time.Second
+		customTransport  = &http.Transport{
+			Dial:                (&net.Dialer{KeepAlive: keepAliveTimeout}).Dial,
+		client     = http.Client{
+			MaxIdleConnsPerHost: 100,
+		}
+		client = http.Client{
+			Transport: customTransport,
+			Timeout:   time.Duration(t) * time.Millisecond,
+		}
+	)
+
 	req, err := http.NewRequest(method, url, nil)
 	CheckErr(err, err)
 	//setting timeout


### PR DESCRIPTION
This PR adds a few improvements on request error handling and minor speed improvements by reusing a more fit transport configuration that handles concurrent requests better.

Also, I added a process time counter in the exit result logs to easily identify how long the fuzzing takes to be finished.

Relates to issue: #7 